### PR TITLE
Add Helm chart for Slumlord operator

### DIFF
--- a/charts/slumlord/.helmignore
+++ b/charts/slumlord/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/slumlord/Chart.yaml
+++ b/charts/slumlord/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: slumlord
+description: A Helm chart for Slumlord - Kubernetes operator for cost optimization
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - kubernetes
+  - operator
+  - cost-optimization
+  - sleep-schedule
+home: https://github.com/cschockaert/slumlord
+maintainers:
+  - name: cschockaert

--- a/charts/slumlord/crds/slumlord.io_slumlordsleepschedules.yaml
+++ b/charts/slumlord/crds/slumlord.io_slumlordsleepschedules.yaml
@@ -1,0 +1,124 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: slumlordsleepschedules.slumlord.io
+spec:
+  group: slumlord.io
+  names:
+    kind: SlumlordSleepSchedule
+    listKind: SlumlordSleepScheduleList
+    plural: slumlordsleepschedules
+    singular: slumlordsleepschedule
+    shortNames:
+      - sss
+      - sleepschedule
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Sleeping
+          type: boolean
+          jsonPath: .status.sleeping
+        - name: Start
+          type: string
+          jsonPath: .spec.schedule.start
+        - name: End
+          type: string
+          jsonPath: .spec.schedule.end
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: SlumlordSleepSchedule defines a sleep schedule for workloads
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - selector
+                - schedule
+              properties:
+                selector:
+                  type: object
+                  description: Selector specifies which workloads to target
+                  properties:
+                    matchLabels:
+                      type: object
+                      additionalProperties:
+                        type: string
+                      description: MatchLabels selects workloads by labels
+                    matchNames:
+                      type: array
+                      items:
+                        type: string
+                      description: MatchNames selects workloads by name
+                    types:
+                      type: array
+                      items:
+                        type: string
+                        enum:
+                          - Deployment
+                          - StatefulSet
+                          - CronJob
+                      description: Types specifies which workload types to target
+                schedule:
+                  type: object
+                  required:
+                    - start
+                    - end
+                  description: Schedule defines when workloads should sleep
+                  properties:
+                    start:
+                      type: string
+                      pattern: '^([01]?[0-9]|2[0-3]):[0-5][0-9]$'
+                      description: Start time in HH:MM format (e.g., "22:00")
+                    end:
+                      type: string
+                      pattern: '^([01]?[0-9]|2[0-3]):[0-5][0-9]$'
+                      description: End time in HH:MM format (e.g., "06:00")
+                    timezone:
+                      type: string
+                      description: Timezone (e.g., "Europe/Paris", "UTC")
+                    days:
+                      type: array
+                      items:
+                        type: integer
+                        minimum: 0
+                        maximum: 6
+                      description: Days of week (0=Sunday, 6=Saturday). Empty means every day.
+            status:
+              type: object
+              properties:
+                sleeping:
+                  type: boolean
+                  description: Whether workloads are currently sleeping
+                lastTransitionTime:
+                  type: string
+                  format: date-time
+                  description: Last time the sleep state changed
+                managedWorkloads:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      originalReplicas:
+                        type: integer
+                        format: int32
+                      originalSuspend:
+                        type: boolean
+                  description: Workloads currently managed by this schedule

--- a/charts/slumlord/templates/NOTES.txt
+++ b/charts/slumlord/templates/NOTES.txt
@@ -1,0 +1,37 @@
+Slumlord has been installed!
+
+1. Verify the operator is running:
+
+   kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "slumlord.name" . }}
+
+2. Create a SlumlordSleepSchedule to put workloads to sleep:
+
+   cat <<EOF | kubectl apply -f -
+   apiVersion: slumlord.io/v1alpha1
+   kind: SlumlordSleepSchedule
+   metadata:
+     name: nightly-sleep
+     namespace: default
+   spec:
+     selector:
+       matchLabels:
+         slumlord.io/managed: "true"
+       types:
+         - Deployment
+         - StatefulSet
+     schedule:
+       start: "22:00"
+       end: "06:00"
+       timezone: "UTC"
+       days: [1, 2, 3, 4, 5]  # Weekdays only
+   EOF
+
+3. Label workloads you want to manage:
+
+   kubectl label deployment my-app slumlord.io/managed=true
+
+4. Check sleep schedules:
+
+   kubectl get slumlordsleepschedules -A
+
+For more information, visit: https://github.com/cschockaert/slumlord

--- a/charts/slumlord/templates/_helpers.tpl
+++ b/charts/slumlord/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "slumlord.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "slumlord.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "slumlord.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "slumlord.labels" -}}
+helm.sh/chart: {{ include "slumlord.chart" . }}
+{{ include "slumlord.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "slumlord.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "slumlord.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "slumlord.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "slumlord.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/slumlord/templates/clusterrole.yaml
+++ b/charts/slumlord/templates/clusterrole.yaml
@@ -1,0 +1,88 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "slumlord.fullname" . }}-manager
+  labels:
+    {{- include "slumlord.labels" . | nindent 4 }}
+rules:
+  # SlumlordSleepSchedule resources
+  - apiGroups:
+      - slumlord.io
+    resources:
+      - slumlordsleepschedules
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - slumlord.io
+    resources:
+      - slumlordsleepschedules/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - slumlord.io
+    resources:
+      - slumlordsleepschedules/finalizers
+    verbs:
+      - update
+  # Deployments
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  # StatefulSets
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  # CronJobs
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  # Leader election
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  # Events
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch

--- a/charts/slumlord/templates/clusterrolebinding.yaml
+++ b/charts/slumlord/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "slumlord.fullname" . }}-manager
+  labels:
+    {{- include "slumlord.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "slumlord.fullname" . }}-manager
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "slumlord.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/slumlord/templates/deployment.yaml
+++ b/charts/slumlord/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "slumlord.fullname" . }}
+  labels:
+    {{- include "slumlord.labels" . | nindent 4 }}
+    control-plane: controller-manager
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "slumlord.selectorLabels" . | nindent 6 }}
+      control-plane: controller-manager
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "slumlord.selectorLabels" . | nindent 8 }}
+        control-plane: controller-manager
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "slumlord.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: manager
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --health-probe-bind-address=:{{ .Values.health.port }}
+            - --metrics-bind-address=:{{ .Values.metrics.port }}
+            {{- if .Values.leaderElection.enabled }}
+            - --leader-elect
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ .Values.health.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/slumlord/templates/serviceaccount.yaml
+++ b/charts/slumlord/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "slumlord.serviceAccountName" . }}
+  labels:
+    {{- include "slumlord.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/slumlord/values.yaml
+++ b/charts/slumlord/values.yaml
@@ -1,0 +1,65 @@
+# Default values for slumlord.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/cschockaert/slumlord
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65532
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Leader election configuration
+leaderElection:
+  enabled: true
+
+# Metrics configuration
+metrics:
+  enabled: true
+  port: 8080
+
+# Health probes configuration
+health:
+  port: 8081


### PR DESCRIPTION
Helm chart includes:
- Deployment with security context and health probes
- ServiceAccount with ClusterRole/ClusterRoleBinding for RBAC
- CRD for SlumlordSleepSchedule
- Configurable resources, replicas, and leader election
- Post-install notes with usage examples