### PR TITLE
Fix GHCR push: add packages write permission

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, lint, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add missing `packages: write` permission to the `docker` job in CI workflow
- Without this permission, the `GITHUB_TOKEN` cannot push images to ghcr.io, which is why the container package was never created

## Test plan
- [ ] Merge and verify the CI `docker` job succeeds on the next push to main
- [ ] Verify `ghcr.io/cschockaert/slumlord:latest` is accessible