### PR TITLE
feat!: add DAYS column and drop v prefix from versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - '[0-9]*'
 
 jobs:
   release:
@@ -53,12 +53,11 @@ jobs:
       - name: Package and push Helm chart
         run: |
           VERSION="${{ steps.version.outputs.VERSION }}"
-          CHART_VERSION="${VERSION#v}"
-          sed -i "s/^version:.*/version: ${CHART_VERSION}/" charts/slumlord/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"${CHART_VERSION}\"/" charts/slumlord/Chart.yaml
+          sed -i "s/^version:.*/version: ${VERSION}/" charts/slumlord/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/slumlord/Chart.yaml
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
           helm package charts/slumlord
-          helm push slumlord-${CHART_VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+          helm push slumlord-${VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
 
       - name: Ensure Helm chart package is public
         run: |

--- a/api/v1alpha1/sleepschedule_types.go
+++ b/api/v1alpha1/sleepschedule_types.go
@@ -52,6 +52,10 @@ type SlumlordSleepScheduleStatus struct {
 	// Sleeping indicates whether workloads are currently sleeping
 	Sleeping bool `json:"sleeping"`
 
+	// DaysDisplay is a human-readable representation of the scheduled days
+	// +optional
+	DaysDisplay string `json:"daysDisplay,omitempty"`
+
 	// ManagedWorkloads lists the workloads being managed
 	// +optional
 	ManagedWorkloads []ManagedWorkload `json:"managedWorkloads,omitempty"`
@@ -87,6 +91,7 @@ type ManagedWorkload struct {
 // +kubebuilder:printcolumn:name="Sleeping",type="boolean",JSONPath=".status.sleeping"
 // +kubebuilder:printcolumn:name="Start",type="string",JSONPath=".spec.schedule.start"
 // +kubebuilder:printcolumn:name="End",type="string",JSONPath=".spec.schedule.end"
+// +kubebuilder:printcolumn:name="Days",type="string",JSONPath=".status.daysDisplay"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // SlumlordSleepSchedule is the Schema for the SlumlordSleepSchedules API

--- a/charts/slumlord/crds/slumlord.io_slumlordsleepschedules.yaml
+++ b/charts/slumlord/crds/slumlord.io_slumlordsleepschedules.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .spec.schedule.end
       name: End
       type: string
+    - jsonPath: .status.daysDisplay
+      name: Days
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -108,6 +111,10 @@ spec:
             description: SlumlordSleepScheduleStatus defines the observed state of
               SlumlordSleepSchedule
             properties:
+              daysDisplay:
+                description: DaysDisplay is a human-readable representation of the
+                  scheduled days
+                type: string
               lastTransitionTime:
                 description: LastTransitionTime is the last time the sleep state changed
                 format: date-time

--- a/config/crd/slumlord.io_slumlordsleepschedules.yaml
+++ b/config/crd/slumlord.io_slumlordsleepschedules.yaml
@@ -24,6 +24,9 @@ spec:
     - jsonPath: .spec.schedule.end
       name: End
       type: string
+    - jsonPath: .status.daysDisplay
+      name: Days
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -108,6 +111,10 @@ spec:
             description: SlumlordSleepScheduleStatus defines the observed state of
               SlumlordSleepSchedule
             properties:
+              daysDisplay:
+                description: DaysDisplay is a human-readable representation of the
+                  scheduled days
+                type: string
               lastTransitionTime:
                 description: LastTransitionTime is the last time the sleep state changed
                 format: date-time

--- a/internal/controller/sleepschedule_controller_test.go
+++ b/internal/controller/sleepschedule_controller_test.go
@@ -22,6 +22,35 @@ import (
 	slumlordv1alpha1 "github.com/cschockaert/slumlord/api/v1alpha1"
 )
 
+func TestDaysToDisplay(t *testing.T) {
+	tests := []struct {
+		name string
+		days []int
+		want string
+	}{
+		{name: "nil days", days: nil, want: "Every day"},
+		{name: "empty days", days: []int{}, want: "Every day"},
+		{name: "weekdays", days: []int{1, 2, 3, 4, 5}, want: "Mon-Fri"},
+		{name: "weekend", days: []int{0, 6}, want: "Sun,Sat"},
+		{name: "non-consecutive", days: []int{1, 3, 5}, want: "Mon,Wed,Fri"},
+		{name: "single day", days: []int{3}, want: "Wed"},
+		{name: "two consecutive", days: []int{1, 2}, want: "Mon,Tue"},
+		{name: "three consecutive", days: []int{1, 2, 3}, want: "Mon-Wed"},
+		{name: "all days", days: []int{0, 1, 2, 3, 4, 5, 6}, want: "Sun-Sat"},
+		{name: "mixed range and single", days: []int{1, 2, 3, 5}, want: "Mon-Wed,Fri"},
+		{name: "unsorted input", days: []int{5, 1, 3}, want: "Mon,Wed,Fri"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := daysToDisplay(tt.days)
+			if got != tt.want {
+				t.Errorf("daysToDisplay(%v) = %q, want %q", tt.days, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestShouldBeSleepingAt(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Add `DAYS` printcolumn to `kubectl get slumlordsleepschedules` showing human-readable day ranges (Mon-Fri, Sat,Sun, Every day)
- Switch release tag scheme from `v*` to plain semver (e.g., `1.0.0` instead of `v1.0.0`)
- Align Docker image tags and Helm chart versions to plain semver

## Breaking Changes
- CRD updated with new `daysDisplay` status field and printcolumn
- Release workflow now triggers on tags without `v` prefix

## Test plan
- [x] `make test` passes (11 new test cases for `daysToDisplay`)
- [x] `make manifests` generates correct CRD with new printcolumn
- [x] Helm chart CRD synced