### PR TITLE
chore(helm): align chart version with release 2.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,11 @@ make uninstall
   - On sleep: scales Deployments/StatefulSets to 0, suspends CronJobs
   - On wake: restores original replica counts and suspend states from status
 
+### Helm Chart (charts/slumlord/)
+
+- `version` and `appVersion` in `Chart.yaml` must always match the latest release tag
+- No `v` prefix (plain semver: `2.0.1`, not `v2.0.1`)
+
 ### Key Design Decisions
 
 1. **State stored in status**: Original workload state (replicas, suspend) is stored in `status.managedWorkloads` to survive operator restarts

--- a/charts/slumlord/Chart.yaml
+++ b/charts/slumlord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: slumlord
 description: A Helm chart for Slumlord - Kubernetes operator for cost optimization
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 2.0.1
+appVersion: "2.0.1"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
Align Helm chart version and appVersion to 2.0.1 to match the latest release tag. Document the versioning convention in CLAUDE.md.