### PR TITLE
docs: update README and CLAUDE.md for idle detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Idle detector feature toggle (#20)
+- Idle detector: MatchNames wildcard selector support
+- Idle detector: CRD validation markers (idleDuration pattern, thresholds 0-100)
+- Idle detector: finalizer deletion path test, partial restore test, name-only selector test
+
+### Fixed
+
+- Idle detector: persist status after each scale-down to prevent data loss on partial failure
+- Idle detector: restore only clears successfully restored workloads, failed ones retained for retry
+- Idle detector: warn on unsupported workload types in selector
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,16 +52,33 @@ make uninstall
 ### CRD Structure (api/v1alpha1/)
 
 - **SlumlordSleepSchedule**: Namespace-scoped resource that defines sleep schedules for workloads
-  - `spec.selector`: Label selector and workload types (Deployment, StatefulSet, CronJob)
+  - `spec.selector`: Label selector, name patterns (wildcards), and workload types (Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization)
   - `spec.schedule`: Time window with start/end times, timezone, and day-of-week filter
   - `status.managedWorkloads`: Tracks original replica counts/suspend states for restoration
+
+- **SlumlordIdleDetector**: Namespace-scoped resource that detects and optionally scales down idle workloads
+  - `spec.selector`: Label selector, name patterns (wildcards), and workload types (Deployment, StatefulSet, CronJob)
+  - `spec.thresholds`: CPU/memory usage thresholds (0-100%)
+  - `spec.idleDuration`: How long a workload must be idle before action (Go duration: `30m`, `1h`)
+  - `spec.action`: `alert` (report only) or `scale` (auto-scale to zero)
+  - `status.idleWorkloads`: Currently detected idle workloads with timestamps
+  - `status.scaledWorkloads`: Workloads scaled down with original state for restoration
+  - **Note**: Metrics collection is stubbed — always returns not-idle. Requires metrics-server/Prometheus integration.
 
 ### Controller (internal/controller/)
 
 - **SleepScheduleReconciler**: Main reconciliation loop
   - Runs every minute to check if current time falls within sleep window
-  - On sleep: scales Deployments/StatefulSets to 0, suspends CronJobs
+  - On sleep: scales Deployments/StatefulSets to 0, suspends CronJobs, hibernates CNPG clusters, suspends FluxCD resources
   - On wake: restores original replica counts and suspend states from status
+  - Finalizer ensures workloads are restored on schedule deletion
+
+- **IdleDetectorReconciler**: Idle workload detection loop
+  - Runs every 5 minutes to check workload resource usage
+  - Supports MatchLabels and/or MatchNames (wildcard glob patterns via `path.Match`)
+  - Status persisted after each scale-down to prevent data loss on partial failure
+  - Restore only clears successfully restored workloads; failed ones retained for retry
+  - Finalizer ensures workloads are restored on detector deletion
 
 ### Helm Chart (charts/slumlord/)
 
@@ -76,7 +93,32 @@ make uninstall
 
 ### Key Design Decisions
 
-1. **State stored in status**: Original workload state (replicas, suspend) is stored in `status.managedWorkloads` to survive operator restarts
+1. **State stored in status**: Original workload state (replicas, suspend) is stored in `status.managedWorkloads` / `status.scaledWorkloads` to survive operator restarts
 2. **Timezone-aware**: Uses Go's `time.LoadLocation` for proper timezone handling
 3. **Overnight schedules**: Handles schedules that cross midnight (e.g., 22:00-06:00)
-4. **Per-namespace**: Each SlumlordSleepSchedule operates within its own namespace
+4. **Per-namespace**: Each SlumlordSleepSchedule/SlumlordIdleDetector operates within its own namespace
+5. **Finalizers**: Both controllers use finalizers to restore workloads on resource deletion
+
+## Release Process
+
+To create a new release:
+
+1. **Update CHANGELOG.md**: Move items from `[Unreleased]` to a new version section, update comparison links at the bottom
+2. **Update Helm chart version**: Set `version` and `appVersion` in `charts/slumlord/Chart.yaml` to the new version
+3. **Update README install command**: Update the `--version` in the Helm install example
+4. **Commit**: Commit changes on a branch, create PR, merge to main
+5. **Tag**: Create a tag on main (no `v` prefix, plain semver: `2.1.0`)
+
+```bash
+git tag 2.1.0
+git push origin 2.1.0
+```
+
+6. **CI does the rest**: The release workflow (`.github/workflows/release.yaml`) triggers on tag push and:
+   - Runs tests
+   - Builds multi-arch Docker image (`linux/amd64`, `linux/arm64`) and pushes to `ghcr.io/cschockaert/slumlord:<version>`
+   - Runs Trivy vulnerability scan (blocks on CRITICAL/HIGH)
+   - Packages and pushes Helm chart to `oci://ghcr.io/cschockaert/charts/slumlord`
+   - Creates a GitHub Release with auto-generated notes
+
+**Important**: No `v` prefix on tags, docker images, or chart versions (plain semver: `2.0.1`, not `v2.0.1`).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Slumlord
 
-Kubernetes operator for cost optimization -- automatically scales down workloads during off-hours.
+Kubernetes operator for cost optimization -- automatically scales down workloads during off-hours and detects idle resources.
 
 ## Features
 
+**Sleep Schedules** -- scale down workloads on a time-based schedule:
 - Scales Deployments and StatefulSets to zero replicas
 - Suspends CronJobs, FluxCD HelmReleases and Kustomizations
 - Hibernates CNPG PostgreSQL clusters
@@ -12,12 +13,23 @@ Kubernetes operator for cost optimization -- automatically scales down workloads
 - Label selectors and name-based matching (with wildcards)
 - State preservation -- original replica counts, suspend states, and hibernation annotations are stored for restoration
 
+**Idle Detection** -- detect and optionally scale down underutilized workloads:
+- Monitors CPU and memory usage against configurable thresholds
+- Configurable idle duration before action
+- Two modes: `alert` (report only) or `scale` (auto-scale to zero)
+- Supports Deployments, StatefulSets, and CronJobs
+- MatchNames wildcard selector (e.g., `prod-*`)
+- Finalizer ensures workloads are restored on detector deletion
+- Tracks original state for safe restoration
+
+> **Note**: Metrics collection is currently stubbed. The idle detector is safe to deploy but requires a future metrics-server/Prometheus integration to actually detect idle workloads.
+
 ## Installation
 
 ### Helm (recommended)
 
 ```bash
-helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 0.2.0
+helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.0.1
 ```
 
 ### From source
@@ -115,6 +127,48 @@ spec:
 
 > **Important**: When managing FluxCD resources alongside Deployments/StatefulSets, use a wider sleep window for the FluxCD schedule. Suspend Flux reconciliation before scaling workloads, and resume it after restoring them. This prevents Flux from restoring scaled-down workloads during the sleep window.
 
+### Idle detection -- alert mode
+
+```yaml
+apiVersion: slumlord.io/v1alpha1
+kind: SlumlordIdleDetector
+metadata:
+  name: idle-alert
+spec:
+  selector:
+    matchLabels:
+      slumlord.io/managed: "true"
+    types:
+      - Deployment
+      - StatefulSet
+  thresholds:
+    cpuPercent: 5
+    memoryPercent: 10
+  idleDuration: "1h"
+  action: alert
+```
+
+### Idle detection -- auto-scale mode
+
+```yaml
+apiVersion: slumlord.io/v1alpha1
+kind: SlumlordIdleDetector
+metadata:
+  name: idle-scaler
+spec:
+  selector:
+    matchNames:
+      - "dev-*"
+      - "staging-*"
+    types:
+      - Deployment
+  thresholds:
+    cpuPercent: 3
+    memoryPercent: 5
+  idleDuration: "2h"
+  action: scale
+```
+
 ## CRD Reference
 
 ### SlumlordSleepSchedule
@@ -129,6 +183,18 @@ spec:
 | `spec.schedule.timezone` | `string` | No | IANA timezone (e.g., `Europe/Paris`). Default: `UTC` |
 | `spec.schedule.days` | `[]int` | No | Days of week (0=Sunday, 6=Saturday). Default: every day |
 
+### SlumlordIdleDetector
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `spec.selector.matchLabels` | `map[string]string` | No | Label selector for target workloads |
+| `spec.selector.matchNames` | `[]string` | No | Name patterns with wildcard support (e.g., `prod-*`) |
+| `spec.selector.types` | `[]string` | No | Workload types: `Deployment`, `StatefulSet`, `CronJob`. Default: all |
+| `spec.thresholds.cpuPercent` | `int32` | No | CPU usage % threshold (0-100). Below = idle |
+| `spec.thresholds.memoryPercent` | `int32` | No | Memory usage % threshold (0-100). Below = idle |
+| `spec.idleDuration` | `string` | Yes | How long a workload must be idle before action (e.g., `30m`, `1h`) |
+| `spec.action` | `string` | Yes | `alert` (report only) or `scale` (auto-scale to zero) |
+
 ### Status
 
 ```
@@ -137,7 +203,15 @@ NAMESPACE   NAME            SLEEPING   START   END     DAYS      AGE
 default     nightly-sleep   false      22:00   06:00   Mon-Fri   19h
 ```
 
+```
+kubectl get slumlordidledetectors -A
+NAMESPACE   NAME          ACTION   IDLE DURATION   LAST CHECK            AGE
+default     idle-alert    alert    1h              2026-02-08T12:00:00Z  1d
+```
+
 ## How it works
+
+### Sleep Schedules
 
 The operator runs a reconciliation loop every minute for each SlumlordSleepSchedule resource:
 
@@ -146,23 +220,40 @@ The operator runs a reconciliation loop every minute for each SlumlordSleepSched
 3. On **wake**: restores all workloads to their original state
 4. Original state (replica counts, suspend flags, hibernation annotations) is stored in `status.managedWorkloads` to survive operator restarts
 
+### Idle Detection
+
+The idle detector reconciles every 5 minutes for each SlumlordIdleDetector resource:
+
+1. Lists workloads matching the selector (labels and/or name patterns)
+2. Checks resource usage against configured thresholds
+3. Tracks how long each workload has been continuously idle
+4. In `alert` mode: reports idle workloads in `status.idleWorkloads`
+5. In `scale` mode: scales down workloads idle longer than `idleDuration`, stores original state in `status.scaledWorkloads`
+6. On detector deletion: restores all scaled workloads via finalizer
+
 ```mermaid
 graph LR
-    A[SlumlordSleepSchedule CR] --> B[Controller]
+    A[SlumlordSleepSchedule] --> B[Sleep Controller]
     B --> C[Deployments]
     B --> D[StatefulSets]
     B --> E[CronJobs]
     B --> F[CNPG Clusters]
     B --> G[HelmReleases]
     B --> H[Kustomizations]
+
+    I[SlumlordIdleDetector] --> J[Idle Controller]
+    J --> C
+    J --> D
+    J --> E
 ```
 
 ## Uninstallation
 
-**Important**: Remove SlumlordSleepSchedule resources before uninstalling to restore workloads.
+**Important**: Remove Slumlord resources before uninstalling to restore workloads.
 
 ```bash
-# Restore all workloads by deleting schedules first
+# Restore all workloads by deleting resources first
+kubectl delete slumlordidledetectors --all -A
 kubectl delete slumlordsleepschedules --all -A
 
 # Then uninstall


### PR DESCRIPTION
## Summary

- Add idle detector feature docs to README (description, usage examples, CRD reference table, status output)
- Update Helm install version from `0.2.0` to `2.0.1`
- Add `SlumlordIdleDetector` architecture docs to CLAUDE.md
- Add release process instructions to CLAUDE.md
- Update CHANGELOG with idle detector hardening entries
- Update mermaid diagram and uninstall instructions

## Test plan

- [x] Docs-only change, no code modified
- [ ] CI passes