### PR TITLE
chore: release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-02-08
+
 ### Added
 
-- Idle detector feature toggle (#20)
-- Idle detector: MatchNames wildcard selector support
-- Idle detector: CRD validation markers (idleDuration pattern, thresholds 0-100)
-- Idle detector: finalizer deletion path test, partial restore test, name-only selector test
+- SlumlordIdleDetector CRD and controller for detecting and scaling down idle workloads
+- Two modes: `alert` (report only) and `scale` (auto-scale to zero after idle duration)
+- MatchNames wildcard selector support (e.g., `prod-*`)
+- CRD validation markers (idleDuration pattern, thresholds 0-100)
+- Finalizer ensures workloads are restored on detector deletion
+- Comprehensive tests: MatchNames filtering, finalizer deletion, partial restore, name-only selector
 
 ### Fixed
 
 - Idle detector: persist status after each scale-down to prevent data loss on partial failure
 - Idle detector: restore only clears successfully restored workloads, failed ones retained for retry
-- Idle detector: warn on unsupported workload types in selector
 
 ### Changed
 
-- Align Helm chart version/appVersion with release 2.0.1
 - Bump actions/checkout from 4 to 6
 - Bump actions/setup-go from 5 to 6
 - Bump sigs.k8s.io/controller-runtime from 0.17.0 to 0.23.1
@@ -65,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Controller tests and CI/CD pipeline
 - Timezone-aware scheduling with overnight schedule support
 
-[Unreleased]: https://github.com/cschockaert/slumlord/compare/2.0.1...HEAD
+[Unreleased]: https://github.com/cschockaert/slumlord/compare/2.1.0...HEAD
+[2.1.0]: https://github.com/cschockaert/slumlord/compare/2.0.1...2.1.0
 [2.0.1]: https://github.com/cschockaert/slumlord/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/cschockaert/slumlord/compare/1.0.0...2.0.0
 [1.0.0]: https://github.com/cschockaert/slumlord/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Kubernetes operator for cost optimization -- automatically scales down workloads
 ### Helm (recommended)
 
 ```bash
-helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.0.1
+helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.1.0
 ```
 
 ### From source

--- a/charts/slumlord/Chart.yaml
+++ b/charts/slumlord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: slumlord
 description: A Helm chart for Slumlord - Kubernetes operator for cost optimization
 type: application
-version: 2.0.1
-appVersion: "2.0.1"
+version: 2.1.0
+appVersion: "2.1.0"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
## Release 2.1.0

### Highlights
- **Idle Resource Detector**: new `SlumlordIdleDetector` CRD with alert and auto-scale modes
- MatchNames wildcard selector, CRD validation, status safety hardening
- Dependency bumps: controller-runtime 0.23.1, actions/checkout v6, actions/setup-go v6

### Checklist
- [x] CHANGELOG updated
- [x] Chart.yaml version/appVersion bumped to 2.1.0
- [x] README install version updated
- [ ] CI green
- [ ] After merge: tag `2.1.0` on main and push