### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-02-09
+
 ### Added
 
+- Embedded dashboard UI served on `:8082` with Tailwind CSS dark theme and auto-refresh
+- API endpoints (`/api/overview`, `/api/schedules`, `/api/idle-detectors`) for schedule visibility
+- Helm chart: dashboard service, optional ingress, network policy
 - SlumlordBinPacker CRD and controller for node consolidation (bin packing)
 - Cluster-scoped resource with optional namespace filter and node selector
 - Two modes: `report` (analyze only) and `consolidate` (evict pods via Eviction API)
@@ -101,7 +106,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Controller tests and CI/CD pipeline
 - Timezone-aware scheduling with overnight schedule support
 
-[Unreleased]: https://github.com/cschockaert/slumlord/compare/2.2.0...HEAD
+[Unreleased]: https://github.com/cschockaert/slumlord/compare/2.3.0...HEAD
+[2.3.0]: https://github.com/cschockaert/slumlord/compare/2.2.0...2.3.0
 [2.2.0]: https://github.com/cschockaert/slumlord/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/cschockaert/slumlord/compare/2.0.1...2.1.0
 [2.0.1]: https://github.com/cschockaert/slumlord/compare/2.0.0...2.0.1

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ Kubernetes operator for cost optimization -- automatically scales down workloads
 - Finalizer ensures workloads are restored on detector deletion
 - Tracks original state for safe restoration
 
-> **Note**: Metrics collection is currently stubbed. The idle detector is safe to deploy but requires a future metrics-server/Prometheus integration to actually detect idle workloads.
+> **Note**: The idle detector requires metrics-server in the cluster. Without it, the operator runs in degraded mode (always returns not-idle).
 
 ## Installation
 
 ### Helm (recommended)
 
 ```bash
-helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.2.0
+helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.3.0
 ```
 
 ### From source

--- a/charts/slumlord/Chart.yaml
+++ b/charts/slumlord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: slumlord
 description: A Helm chart for Slumlord - Kubernetes operator for cost optimization
 type: application
-version: 2.2.0
-appVersion: "2.2.0"
+version: 2.3.0
+appVersion: "2.3.0"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
## Summary

- Dashboard UI: embedded web dashboard on `:8082` with schedule overview, managed workloads, idle detectors, and 24h timeline
- BinPacker: new `SlumlordBinPacker` CRD and controller for node consolidation via bin packing
- Fix outdated README note about metrics being stubbed (real metrics-server integration landed in 2.2.0)

## Checklist

- [x] CHANGELOG.md updated (Unreleased -> 2.3.0)
- [x] Chart.yaml version + appVersion bumped
- [x] README helm install version bumped
- [x] README metrics note corrected