### PR TITLE
feat: support Prometheus Operator CRDs (ThanosRuler, Alertmanager, Prometheus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for Prometheus Operator CRDs: `ThanosRuler`, `Alertmanager`, `Prometheus` in SlumlordSleepSchedule
+- Generic `sleepReplicaResources`/`wakeReplicaResource` functions for any CRD using `spec.replicas`
+- RBAC permissions for `monitoring.coreos.com` resources (thanosrulers, alertmanagers, prometheuses)
+- Graceful handling when Prometheus Operator CRDs are not installed (skip with log, no crash)
+
 ## [2.4.0] - 2026-02-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ make uninstall
 ### CRD Structure (api/v1alpha1/)
 
 - **SlumlordSleepSchedule**: Namespace-scoped resource that defines sleep schedules for workloads
-  - `spec.selector`: Label selector, name patterns (wildcards), and workload types (Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization)
+  - `spec.selector`: Label selector, name patterns (wildcards), and workload types (Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus)
   - `spec.schedule`: Time window with start/end times, timezone, and day-of-week filter
   - `status.managedWorkloads`: Tracks original replica counts/suspend states for restoration
 
@@ -69,7 +69,7 @@ make uninstall
 
 - **SleepScheduleReconciler**: Main reconciliation loop
   - Runs every minute to check if current time falls within sleep window
-  - On sleep: scales Deployments/StatefulSets to 0, suspends CronJobs, hibernates CNPG clusters, suspends FluxCD resources
+  - On sleep: scales Deployments/StatefulSets to 0, scales Prometheus Operator CRDs (ThanosRuler, Alertmanager, Prometheus) to 0, suspends CronJobs, hibernates CNPG clusters, suspends FluxCD resources
   - On wake: restores original replica counts and suspend states from status
   - Finalizer ensures workloads are restored on schedule deletion
 

--- a/api/v1alpha1/sleepschedule_types.go
+++ b/api/v1alpha1/sleepschedule_types.go
@@ -24,7 +24,7 @@ type WorkloadSelector struct {
 	MatchNames []string `json:"matchNames,omitempty"`
 
 	// Types specifies which workload types to target
-	// Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization
+	// Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus
 	// +optional
 	Types []string `json:"types,omitempty"`
 }
@@ -71,7 +71,7 @@ type SlumlordSleepScheduleStatus struct {
 
 // ManagedWorkload tracks a workload managed by this schedule
 type ManagedWorkload struct {
-	// Kind is the workload kind (Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization)
+	// Kind is the workload kind (Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus)
 	Kind string `json:"kind"`
 
 	// Name is the workload name

--- a/charts/slumlord/crds/slumlord.io_slumlordidledetectors.yaml
+++ b/charts/slumlord/crds/slumlord.io_slumlordidledetectors.yaml
@@ -82,7 +82,7 @@ spec:
                   types:
                     description: |-
                       Types specifies which workload types to target
-                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization
+                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus
                     items:
                       type: string
                     type: array

--- a/charts/slumlord/crds/slumlord.io_slumlordsleepschedules.yaml
+++ b/charts/slumlord/crds/slumlord.io_slumlordsleepschedules.yaml
@@ -102,7 +102,7 @@ spec:
                   types:
                     description: |-
                       Types specifies which workload types to target
-                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization
+                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus
                     items:
                       type: string
                     type: array
@@ -130,7 +130,8 @@ spec:
                   properties:
                     kind:
                       description: Kind is the workload kind (Deployment, StatefulSet,
-                        CronJob, Cluster, HelmRelease, Kustomization)
+                        CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler,
+                        Alertmanager, Prometheus)
                       type: string
                     name:
                       description: Name is the workload name

--- a/charts/slumlord/templates/clusterrole.yaml
+++ b/charts/slumlord/templates/clusterrole.yaml
@@ -98,6 +98,19 @@ rules:
       - patch
       - update
       - watch
+  # Prometheus Operator CRDs (ThanosRuler, Alertmanager, Prometheus)
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - thanosrulers
+      - alertmanagers
+      - prometheuses
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
   # SlumlordIdleDetector read-only (dashboard needs these even when controller is disabled)
   - apiGroups:
       - slumlord.io

--- a/config/crd/slumlord.io_slumlordidledetectors.yaml
+++ b/config/crd/slumlord.io_slumlordidledetectors.yaml
@@ -82,7 +82,7 @@ spec:
                   types:
                     description: |-
                       Types specifies which workload types to target
-                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization
+                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus
                     items:
                       type: string
                     type: array

--- a/config/crd/slumlord.io_slumlordsleepschedules.yaml
+++ b/config/crd/slumlord.io_slumlordsleepschedules.yaml
@@ -102,7 +102,7 @@ spec:
                   types:
                     description: |-
                       Types specifies which workload types to target
-                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization
+                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus
                     items:
                       type: string
                     type: array
@@ -130,7 +130,8 @@ spec:
                   properties:
                     kind:
                       description: Kind is the workload kind (Deployment, StatefulSet,
-                        CronJob, Cluster, HelmRelease, Kustomization)
+                        CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler,
+                        Alertmanager, Prometheus)
                       type: string
                     name:
                       description: Name is the workload name


### PR DESCRIPTION
## Summary

- Add sleep/wake support for Prometheus Operator CRDs (`ThanosRuler`, `Alertmanager`, `Prometheus`) via `spec.replicas` scaling
- Generic `sleepReplicaResources`/`wakeReplicaResource` functions reusable for any CRD with `spec.replicas`
- RBAC for `monitoring.coreos.com` resources, graceful skip when CRDs not installed
- 6 new tests (sleep + wake for each type), updated CHANGELOG, README, Helm chart RBAC

## Test plan

- [x] `TestReconcile_ScalesDownThanosRuler` — verifies ThanosRuler scaled to 0 on sleep
- [x] `TestReconcile_ScalesDownAlertmanager` — verifies Alertmanager scaled to 0 on sleep
- [x] `TestReconcile_ScalesDownPrometheus` — verifies Prometheus scaled to 0 on sleep
- [x] `TestReconcile_WakesThanosRuler` — verifies ThanosRuler restored on wake
- [x] `TestReconcile_WakesAlertmanager` — verifies Alertmanager restored on wake
- [x] `TestReconcile_WakesPrometheus` — verifies Prometheus restored on wake
- [x] RBAC added to Helm ClusterRole template
- [x] CRD manifests regenerated

Closes #32