### PR TITLE
chore: release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-02-10
+
 ### Added
 
 - Support for Prometheus Operator CRDs: `ThanosRuler`, `Alertmanager`, `Prometheus` in SlumlordSleepSchedule
@@ -128,7 +130,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Controller tests and CI/CD pipeline
 - Timezone-aware scheduling with overnight schedule support
 
-[Unreleased]: https://github.com/cschockaert/slumlord/compare/2.4.0...HEAD
+[Unreleased]: https://github.com/cschockaert/slumlord/compare/2.5.0...HEAD
+[2.5.0]: https://github.com/cschockaert/slumlord/compare/2.4.0...2.5.0
 [2.4.0]: https://github.com/cschockaert/slumlord/compare/2.3.0...2.4.0
 [2.3.0]: https://github.com/cschockaert/slumlord/compare/2.2.0...2.3.0
 [2.2.0]: https://github.com/cschockaert/slumlord/compare/2.1.0...2.2.0

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Kubernetes operator for cost optimization -- automatically scales down workloads
 ### Helm (recommended)
 
 ```bash
-helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.4.0
+helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.5.0
 ```
 
 ### From source

--- a/charts/slumlord/Chart.yaml
+++ b/charts/slumlord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: slumlord
 description: A Helm chart for Slumlord - Kubernetes operator for cost optimization
 type: application
-version: 2.4.0
-appVersion: "2.4.0"
+version: 2.5.0
+appVersion: "2.5.0"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
## Summary

- Bump version to 2.5.0 in Chart.yaml, README, and CHANGELOG
- Move Unreleased items to 2.5.0 section