### PR TITLE
feat: add MariaDB Operator CRD support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for MariaDB Operator CRDs: `MariaDB` and `MaxScale` in SlumlordSleepSchedule
+- Suspend/resume reconciliation via `spec.suspend` (same pattern as FluxCD)
+- RBAC permissions for `k8s.mariadb.com` resources (mariadbs, maxscales)
+- Graceful handling when MariaDB Operator CRDs are not installed (skip with log, no crash)
+
+### Changed
+
+- Renamed `sleepFluxResources`/`wakeFluxResource` to generic `sleepSuspendResources`/`wakeSuspendResource`
+- Fixed wake tests to be time-independent (no more failures during 23:00-23:59 UTC)
+
 ## [2.5.0] - 2026-02-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ make uninstall
 ### CRD Structure (api/v1alpha1/)
 
 - **SlumlordSleepSchedule**: Namespace-scoped resource that defines sleep schedules for workloads
-  - `spec.selector`: Label selector, name patterns (wildcards), and workload types (Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus)
+  - `spec.selector`: Label selector, name patterns (wildcards), and workload types (Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus, MariaDB, MaxScale)
   - `spec.schedule`: Time window with start/end times, timezone, and day-of-week filter
   - `status.managedWorkloads`: Tracks original replica counts/suspend states for restoration
 
@@ -69,7 +69,7 @@ make uninstall
 
 - **SleepScheduleReconciler**: Main reconciliation loop
   - Runs every minute to check if current time falls within sleep window
-  - On sleep: scales Deployments/StatefulSets to 0, scales Prometheus Operator CRDs (ThanosRuler, Alertmanager, Prometheus) to 0, suspends CronJobs, hibernates CNPG clusters, suspends FluxCD resources
+  - On sleep: scales Deployments/StatefulSets to 0, scales Prometheus Operator CRDs (ThanosRuler, Alertmanager, Prometheus) to 0, suspends CronJobs, hibernates CNPG clusters, suspends FluxCD resources, suspends MariaDB Operator CRDs (MariaDB, MaxScale)
   - On wake: restores original replica counts and suspend states from status
   - Finalizer ensures workloads are restored on schedule deletion
 

--- a/api/v1alpha1/sleepschedule_types.go
+++ b/api/v1alpha1/sleepschedule_types.go
@@ -24,7 +24,7 @@ type WorkloadSelector struct {
 	MatchNames []string `json:"matchNames,omitempty"`
 
 	// Types specifies which workload types to target
-	// Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus
+	// Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus, MariaDB, MaxScale
 	// +optional
 	Types []string `json:"types,omitempty"`
 }
@@ -71,7 +71,7 @@ type SlumlordSleepScheduleStatus struct {
 
 // ManagedWorkload tracks a workload managed by this schedule
 type ManagedWorkload struct {
-	// Kind is the workload kind (Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus)
+	// Kind is the workload kind (Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus, MariaDB, MaxScale)
 	Kind string `json:"kind"`
 
 	// Name is the workload name
@@ -81,7 +81,7 @@ type ManagedWorkload struct {
 	// +optional
 	OriginalReplicas *int32 `json:"originalReplicas,omitempty"`
 
-	// OriginalSuspend stores the suspend state before sleeping (for CronJob, HelmRelease, Kustomization)
+	// OriginalSuspend stores the suspend state before sleeping (for CronJob, HelmRelease, Kustomization, MariaDB, MaxScale)
 	// +optional
 	OriginalSuspend *bool `json:"originalSuspend,omitempty"`
 

--- a/charts/slumlord/crds/slumlord.io_slumlordidledetectors.yaml
+++ b/charts/slumlord/crds/slumlord.io_slumlordidledetectors.yaml
@@ -82,7 +82,7 @@ spec:
                   types:
                     description: |-
                       Types specifies which workload types to target
-                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus
+                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus, MariaDB, MaxScale
                     items:
                       type: string
                     type: array

--- a/charts/slumlord/crds/slumlord.io_slumlordsleepschedules.yaml
+++ b/charts/slumlord/crds/slumlord.io_slumlordsleepschedules.yaml
@@ -102,7 +102,7 @@ spec:
                   types:
                     description: |-
                       Types specifies which workload types to target
-                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus
+                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus, MariaDB, MaxScale
                     items:
                       type: string
                     type: array
@@ -131,7 +131,7 @@ spec:
                     kind:
                       description: Kind is the workload kind (Deployment, StatefulSet,
                         CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler,
-                        Alertmanager, Prometheus)
+                        Alertmanager, Prometheus, MariaDB, MaxScale)
                       type: string
                     name:
                       description: Name is the workload name
@@ -147,7 +147,8 @@ spec:
                       type: integer
                     originalSuspend:
                       description: OriginalSuspend stores the suspend state before
-                        sleeping (for CronJob, HelmRelease, Kustomization)
+                        sleeping (for CronJob, HelmRelease, Kustomization, MariaDB,
+                        MaxScale)
                       type: boolean
                   required:
                   - kind

--- a/charts/slumlord/templates/clusterrole.yaml
+++ b/charts/slumlord/templates/clusterrole.yaml
@@ -111,6 +111,18 @@ rules:
       - patch
       - update
       - watch
+  # MariaDB Operator CRDs (MariaDB, MaxScale)
+  - apiGroups:
+      - k8s.mariadb.com
+    resources:
+      - mariadbs
+      - maxscales
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
   # SlumlordIdleDetector read-only (dashboard needs these even when controller is disabled)
   - apiGroups:
       - slumlord.io

--- a/config/crd/slumlord.io_slumlordidledetectors.yaml
+++ b/config/crd/slumlord.io_slumlordidledetectors.yaml
@@ -82,7 +82,7 @@ spec:
                   types:
                     description: |-
                       Types specifies which workload types to target
-                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus
+                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus, MariaDB, MaxScale
                     items:
                       type: string
                     type: array

--- a/config/crd/slumlord.io_slumlordsleepschedules.yaml
+++ b/config/crd/slumlord.io_slumlordsleepschedules.yaml
@@ -102,7 +102,7 @@ spec:
                   types:
                     description: |-
                       Types specifies which workload types to target
-                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus
+                      Valid values: Deployment, StatefulSet, CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler, Alertmanager, Prometheus, MariaDB, MaxScale
                     items:
                       type: string
                     type: array
@@ -131,7 +131,7 @@ spec:
                     kind:
                       description: Kind is the workload kind (Deployment, StatefulSet,
                         CronJob, Cluster, HelmRelease, Kustomization, ThanosRuler,
-                        Alertmanager, Prometheus)
+                        Alertmanager, Prometheus, MariaDB, MaxScale)
                       type: string
                     name:
                       description: Name is the workload name
@@ -147,7 +147,8 @@ spec:
                       type: integer
                     originalSuspend:
                       description: OriginalSuspend stores the suspend state before
-                        sleeping (for CronJob, HelmRelease, Kustomization)
+                        sleeping (for CronJob, HelmRelease, Kustomization, MariaDB,
+                        MaxScale)
                       type: boolean
                   required:
                   - kind


### PR DESCRIPTION
## Summary

- Add `MariaDB` and `MaxScale` CRD support via `spec.suspend` (same pattern as FluxCD)
- RBAC permissions for `k8s.mariadb.com` resources
- Graceful handling when MariaDB Operator CRDs are not installed
- Renamed internal `sleepFluxResources`/`wakeFluxResource` to generic `sleepSuspendResources`/`wakeSuspendResource`
- 4 new tests: sleep/wake for MariaDB and MaxScale

## Test plan

- [x] `make test` passes
- [x] MariaDB sleep test: verifies `spec.suspend = true` on sleep
- [x] MariaDB wake test: verifies `spec.suspend` restored on wake
- [x] MaxScale sleep/wake tests: same pattern