### PR TITLE
chore: release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-02-10
+
 ### Added
 
 - Support for MariaDB Operator CRDs: `MariaDB` and `MaxScale` in SlumlordSleepSchedule
@@ -142,7 +144,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Controller tests and CI/CD pipeline
 - Timezone-aware scheduling with overnight schedule support
 
-[Unreleased]: https://github.com/cschockaert/slumlord/compare/2.5.0...HEAD
+[Unreleased]: https://github.com/cschockaert/slumlord/compare/2.6.0...HEAD
+[2.6.0]: https://github.com/cschockaert/slumlord/compare/2.5.0...2.6.0
 [2.5.0]: https://github.com/cschockaert/slumlord/compare/2.4.0...2.5.0
 [2.4.0]: https://github.com/cschockaert/slumlord/compare/2.3.0...2.4.0
 [2.3.0]: https://github.com/cschockaert/slumlord/compare/2.2.0...2.3.0

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Kubernetes operator for cost optimization -- automatically scales down workloads
 ### Helm (recommended)
 
 ```bash
-helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.5.0
+helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.6.0
 ```
 
 ### From source

--- a/charts/slumlord/Chart.yaml
+++ b/charts/slumlord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: slumlord
 description: A Helm chart for Slumlord - Kubernetes operator for cost optimization
 type: application
-version: 2.5.0
-appVersion: "2.5.0"
+version: 2.6.0
+appVersion: "2.6.0"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
## Summary

- Release 2.6.0 with MariaDB Operator CRD support
- Bump Chart.yaml version/appVersion to 2.6.0
- Update CHANGELOG with 2.6.0 section
- Update README helm install version

## Changes in 2.6.0

- MariaDB and MaxScale CRD support via `spec.suspend`
- Generic suspend/resume functions (renamed from Flux-specific)
- Time-independent wake tests fix