### PR TITLE
chore: release 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-02-12
+
+### Added
+
+- PDB/replica-aware safety for BinPacker consolidation plan
+- Disruption budget checks before pod evictions (respects PDB `DisruptionsAllowed`)
+- Fallback safety: require at least 2 ready replicas when no PDB exists
+- Support for both Deployment and StatefulSet workload resolution
+- Performance considerations note in README
+
 ## [2.8.0] - 2026-02-12
 
 ### Added
@@ -172,7 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Controller tests and CI/CD pipeline
 - Timezone-aware scheduling with overnight schedule support
 
-[Unreleased]: https://github.com/cschockaert/slumlord/compare/2.8.0...HEAD
+[Unreleased]: https://github.com/cschockaert/slumlord/compare/2.9.0...HEAD
+[2.9.0]: https://github.com/cschockaert/slumlord/compare/2.8.0...2.9.0
 [2.8.0]: https://github.com/cschockaert/slumlord/compare/2.7.0...2.8.0
 [2.7.0]: https://github.com/cschockaert/slumlord/compare/2.6.0...2.7.0
 [2.6.0]: https://github.com/cschockaert/slumlord/compare/2.5.0...2.6.0

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Kubernetes operator for cost optimization -- automatically scales down workloads
 ### Helm (recommended)
 
 ```bash
-helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.8.0
+helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.9.0
 ```
 
 ### From source

--- a/charts/slumlord/Chart.yaml
+++ b/charts/slumlord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: slumlord
 description: A Helm chart for Slumlord - Kubernetes operator for cost optimization
 type: application
-version: 2.8.0
-appVersion: "2.8.0"
+version: 2.9.0
+appVersion: "2.9.0"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
## Summary

- Release 2.9.0
- Update CHANGELOG, Chart.yaml, README install version

## Changes in 2.9.0

- PDB/replica-aware safety for BinPacker consolidation plan
- Disruption budget checks before pod evictions
- Fallback safety: require ≥2 ready replicas when no PDB exists
- Deployment and StatefulSet workload resolution support