### PR TITLE
chore: use standard v prefix for release tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release:
@@ -40,7 +40,7 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,18 +216,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Controller tests and CI/CD pipeline
 - Timezone-aware scheduling with overnight schedule support
 
-[Unreleased]: https://github.com/cschockaert/slumlord/compare/2.11.0...HEAD
-[2.11.0]: https://github.com/cschockaert/slumlord/compare/2.10.0...2.11.0
-[2.10.0]: https://github.com/cschockaert/slumlord/compare/2.9.0...2.10.0
-[2.9.0]: https://github.com/cschockaert/slumlord/compare/2.8.0...2.9.0
-[2.8.0]: https://github.com/cschockaert/slumlord/compare/2.7.0...2.8.0
-[2.7.0]: https://github.com/cschockaert/slumlord/compare/2.6.0...2.7.0
-[2.6.0]: https://github.com/cschockaert/slumlord/compare/2.5.0...2.6.0
-[2.5.0]: https://github.com/cschockaert/slumlord/compare/2.4.0...2.5.0
-[2.4.0]: https://github.com/cschockaert/slumlord/compare/2.3.0...2.4.0
-[2.3.0]: https://github.com/cschockaert/slumlord/compare/2.2.0...2.3.0
-[2.2.0]: https://github.com/cschockaert/slumlord/compare/2.1.0...2.2.0
-[2.1.0]: https://github.com/cschockaert/slumlord/compare/2.0.1...2.1.0
-[2.0.1]: https://github.com/cschockaert/slumlord/compare/2.0.0...2.0.1
-[2.0.0]: https://github.com/cschockaert/slumlord/compare/1.0.0...2.0.0
-[1.0.0]: https://github.com/cschockaert/slumlord/releases/tag/1.0.0
+[Unreleased]: https://github.com/cschockaert/slumlord/compare/v2.12.0...HEAD
+[2.12.0]: https://github.com/cschockaert/slumlord/compare/v2.11.0...v2.12.0
+[2.11.0]: https://github.com/cschockaert/slumlord/compare/v2.10.0...v2.11.0
+[2.10.0]: https://github.com/cschockaert/slumlord/compare/v2.9.0...v2.10.0
+[2.9.0]: https://github.com/cschockaert/slumlord/compare/v2.8.0...v2.9.0
+[2.8.0]: https://github.com/cschockaert/slumlord/compare/v2.7.0...v2.8.0
+[2.7.0]: https://github.com/cschockaert/slumlord/compare/v2.6.0...v2.7.0
+[2.6.0]: https://github.com/cschockaert/slumlord/compare/v2.5.0...v2.6.0
+[2.5.0]: https://github.com/cschockaert/slumlord/compare/v2.4.0...v2.5.0
+[2.4.0]: https://github.com/cschockaert/slumlord/compare/v2.3.0...v2.4.0
+[2.3.0]: https://github.com/cschockaert/slumlord/compare/v2.2.0...v2.3.0
+[2.2.0]: https://github.com/cschockaert/slumlord/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/cschockaert/slumlord/compare/v2.0.1...v2.1.0
+[2.0.1]: https://github.com/cschockaert/slumlord/compare/v2.0.0...v2.0.1
+[2.0.0]: https://github.com/cschockaert/slumlord/compare/v1.0.0...v2.0.0
+[1.0.0]: https://github.com/cschockaert/slumlord/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,8 @@ make uninstall
 
 ### Helm Chart (charts/slumlord/)
 
-- `version` and `appVersion` in `Chart.yaml` must always match the latest release tag
-- No `v` prefix (plain semver: `2.0.1`, not `v2.0.1`)
+- `version` and `appVersion` in `Chart.yaml` must always match the latest release tag (plain semver, no `v` prefix)
+- Tags use standard `v` prefix (e.g., `v2.12.0`), but Docker images and Helm chart versions use plain semver (e.g., `2.12.0`)
 
 ### Changelog (CHANGELOG.md)
 
@@ -125,11 +125,11 @@ To create a new release:
 2. **Update Helm chart version**: Set `version` and `appVersion` in `charts/slumlord/Chart.yaml` to the new version
 3. **Update README install command**: Update the `--version` in the Helm install example
 4. **Commit**: Commit changes on a branch, create PR, merge to main
-5. **Tag**: Create a tag on main (no `v` prefix, plain semver: `2.1.0`)
+5. **Tag**: Create a tag on main with `v` prefix
 
 ```bash
-git tag 2.1.0
-git push origin 2.1.0
+git tag v2.13.0
+git push origin v2.13.0
 ```
 
 6. **CI does the rest**: The release workflow (`.github/workflows/release.yaml`) triggers on tag push and:
@@ -139,4 +139,4 @@ git push origin 2.1.0
    - Packages and pushes Helm chart to `oci://ghcr.io/cschockaert/charts/slumlord`
    - Creates a GitHub Release with auto-generated notes
 
-**Important**: No `v` prefix on tags, docker images, or chart versions (plain semver: `2.0.1`, not `v2.0.1`).
+**Important**: Tags use `v` prefix (e.g., `v2.13.0`). Docker images and Helm chart versions use plain semver (the `v` is stripped by CI).


### PR DESCRIPTION
## Summary

- Release workflow now triggers on `vX.Y.Z` tags instead of `X.Y.Z`
- CI strips the `v` prefix so Docker images and Helm chart versions stay plain semver
- CHANGELOG comparison links updated to use `v`-prefixed tags
- All existing tags retagged with `v` prefix (old tags kept for now)