### PR TITLE
chore: release 2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.1] - 2026-03-03
+
+### Fixed
+
+- Conflict error during `sleepWorkloads` no longer causes loss of `ManagedWorkloads` (#64)
+- Status is now persisted after each workload type section so partial progress survives retries
+- Workload entries are appended to `ManagedWorkloads` only after successful scale-down
+
 ## [2.13.0] - 2026-02-20
 
 ### Added
@@ -234,7 +242,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Controller tests and CI/CD pipeline
 - Timezone-aware scheduling with overnight schedule support
 
-[Unreleased]: https://github.com/cschockaert/slumlord/compare/v2.13.0...HEAD
+[Unreleased]: https://github.com/cschockaert/slumlord/compare/v2.13.1...HEAD
+[2.13.1]: https://github.com/cschockaert/slumlord/compare/v2.13.0...v2.13.1
 [2.13.0]: https://github.com/cschockaert/slumlord/compare/v2.12.1...v2.13.0
 [2.12.1]: https://github.com/cschockaert/slumlord/compare/v2.12.0...v2.12.1
 [2.12.0]: https://github.com/cschockaert/slumlord/compare/v2.11.0...v2.12.0

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Kubernetes operator for cost optimization -- automatically scales down workloads
 ### Helm (recommended)
 
 ```bash
-helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.13.0
+helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.13.1
 ```
 
 ### From source

--- a/charts/slumlord/Chart.yaml
+++ b/charts/slumlord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: slumlord
 description: A Helm chart for Slumlord - Kubernetes operator for cost optimization
 type: application
-version: 2.13.0
-appVersion: "2.13.0"
+version: 2.13.1
+appVersion: "2.13.1"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
## Summary

- Bump version to 2.13.1 (Chart.yaml, README)
- Update CHANGELOG with fix for ManagedWorkloads loss on conflict (#64)

## Test plan

- [x] CI passes
- [ ] Tag `v2.13.1` after merge triggers release workflow