### PR TITLE
build(deps): bump trivy-action from 0.34.0 to 0.34.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.34.2
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
           format: 'table'


### PR DESCRIPTION
## Summary

- Bump `aquasecurity/trivy-action` from 0.34.0 to 0.34.2
- Fixes release pipeline failure: Trivy v0.69.1 was removed from GitHub, causing binary download to fail
- v0.34.2 uses Trivy v0.69.2 which is available

## Test plan

- [x] Release workflow should succeed after merge + re-tag