### PR TITLE
chore: release 2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.0] - 2026-03-04
+
 ### Added
 
 - Support multiple sleep windows per schedule via `spec.schedules` (#63)
@@ -249,7 +251,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Controller tests and CI/CD pipeline
 - Timezone-aware scheduling with overnight schedule support
 
-[Unreleased]: https://github.com/cschockaert/slumlord/compare/v2.13.1...HEAD
+[Unreleased]: https://github.com/cschockaert/slumlord/compare/v2.14.0...HEAD
+[2.14.0]: https://github.com/cschockaert/slumlord/compare/v2.13.1...v2.14.0
 [2.13.1]: https://github.com/cschockaert/slumlord/compare/v2.13.0...v2.13.1
 [2.13.0]: https://github.com/cschockaert/slumlord/compare/v2.12.1...v2.13.0
 [2.12.1]: https://github.com/cschockaert/slumlord/compare/v2.12.0...v2.12.1

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Kubernetes operator for cost optimization -- automatically scales down workloads
 ### Helm (recommended)
 
 ```bash
-helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.13.1
+helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.14.0
 ```
 
 ### From source

--- a/charts/slumlord/Chart.yaml
+++ b/charts/slumlord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: slumlord
 description: A Helm chart for Slumlord - Kubernetes operator for cost optimization
 type: application
-version: 2.13.1
-appVersion: "2.13.1"
+version: 2.14.0
+appVersion: "2.14.0"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
## Summary

- Release 2.14.0 with multi-window sleep schedules (#63)
- Update CHANGELOG, Helm chart version, README install command

## Test plan

- [ ] CI passes
- [ ] Tag `v2.14.0` after merge triggers release workflow