### PR TITLE
release: v2.14.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
         run: make test
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: cover.out
         continue-on-error: true
@@ -85,7 +85,7 @@ jobs:
         run: go build -v ./cmd/main.go
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Lint Helm chart
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
           format: 'table'
@@ -63,7 +63,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Package and push Helm chart
         run: |
@@ -82,6 +82,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.3] - 2026-04-26
+
+### Changed
+
+- Bump aquasecurity/trivy-action from 0.35.0 to 0.36.0 (#105)
+- Bump azure/setup-helm from 4 to 5 (#99)
+- Bump codecov/codecov-action from 5 to 6 (#98)
+- Bump softprops/action-gh-release from 2 to 3 (#100)
+
 ## [2.14.2] - 2026-03-26
 
 ### Fixed
@@ -265,7 +274,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Controller tests and CI/CD pipeline
 - Timezone-aware scheduling with overnight schedule support
 
-[Unreleased]: https://github.com/cschockaert/slumlord/compare/v2.14.2...HEAD
+[Unreleased]: https://github.com/cschockaert/slumlord/compare/v2.14.3...HEAD
+[2.14.3]: https://github.com/cschockaert/slumlord/compare/v2.14.2...v2.14.3
 [2.14.2]: https://github.com/cschockaert/slumlord/compare/v2.14.1...v2.14.2
 [2.14.1]: https://github.com/cschockaert/slumlord/compare/v2.14.0...v2.14.1
 [2.14.0]: https://github.com/cschockaert/slumlord/compare/v2.13.1...v2.14.0

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Kubernetes operator for cost optimization -- automatically scales down workloads
 ### Helm (recommended)
 
 ```bash
-helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.14.2
+helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.14.3
 ```
 
 ### From source

--- a/charts/slumlord/Chart.yaml
+++ b/charts/slumlord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: slumlord
 description: A Helm chart for Slumlord - Kubernetes operator for cost optimization
 type: application
-version: 2.14.2
-appVersion: "2.14.2"
+version: 2.14.3
+appVersion: "2.14.3"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
Bump GitHub Actions dependencies and prepare 2.14.3 release.

- Bump aquasecurity/trivy-action from 0.35.0 to 0.36.0 (#105)
- Bump azure/setup-helm from 4 to 5 (#99)
- Bump codecov/codecov-action from 5 to 6 (#98)
- Bump softprops/action-gh-release from 2 to 3 (#100)

The k8s.io 0.36.0 dependabot bumps (#106-#109) are blocked: latest
controller-runtime v0.23.3 doesn't implement HasSyncedChecker on
ResourceEventHandlerRegistration introduced in client-go v0.36.0.
Will revisit once controller-runtime v0.24.0 is released.

https://claude.ai/code/session_016ciLrX1C9JnAXtWnzV7bin