### PR TITLE
release: v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.16.0] - 2026-05-28
+
 ### Added
 
 - `SlumlordAutoSchedulePolicy` cluster-scoped CRD: fan out `SlumlordSleepSchedule` to many namespaces with a single label opt-in (`slumlord.io/sleep-profile: <profile>`) ([#118](https://github.com/cschockaert/slumlord/issues/118))
 - Profile-based templates declared once on the policy; namespace label value picks one
 - Cleanup via finalizer + `slumlord.io/managed-by-policy` label (Kubernetes forbids cross-namespace ownerReferences)
 - Manually-managed `SlumlordSleepSchedule` resources are never touched (conflict surfaced in `status.conflicts`)
-- Multi-policy overlap on the same namespace fails closed and surfaces in `status.conflicts`
+- Multi-policy overlap on the same namespace fails closed; conflict surfaces bidirectionally on every overlapping policy via a peer-policy watch
 - Feature flag `--enable-autoschedule-policy` (off by default)
 - Helm value `autoSchedulePolicy.enabled`
 
@@ -292,7 +294,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Controller tests and CI/CD pipeline
 - Timezone-aware scheduling with overnight schedule support
 
-[Unreleased]: https://github.com/cschockaert/slumlord/compare/v2.15.0...HEAD
+[Unreleased]: https://github.com/cschockaert/slumlord/compare/v2.16.0...HEAD
+[2.16.0]: https://github.com/cschockaert/slumlord/compare/v2.15.0...v2.16.0
 [2.15.0]: https://github.com/cschockaert/slumlord/compare/v2.14.3...v2.15.0
 [2.14.3]: https://github.com/cschockaert/slumlord/compare/v2.14.2...v2.14.3
 [2.14.2]: https://github.com/cschockaert/slumlord/compare/v2.14.1...v2.14.2

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Kubernetes operator for cost optimization -- automatically scales down workloads
 ### Helm (recommended)
 
 ```bash
-helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.15.0
+helm install slumlord oci://ghcr.io/cschockaert/charts/slumlord --version 2.16.0
 ```
 
 ### From source

--- a/charts/slumlord/Chart.yaml
+++ b/charts/slumlord/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: slumlord
 description: A Helm chart for Slumlord - Kubernetes operator for cost optimization
 type: application
-version: 2.15.0
-appVersion: "2.15.0"
+version: 2.16.0
+appVersion: "2.16.0"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
## Summary

Cuts release v2.16.0 — first version shipping the `SlumlordAutoSchedulePolicy` CRD (merged via #120, closes #118).

- Helm chart `version` + `appVersion` → 2.16.0
- README install command bumped
- CHANGELOG: moves Unreleased entries under [2.16.0] with comparison link

## Test plan

- [x] Helm + README + CHANGELOG bumped consistently
- [ ] CI green
- [ ] After merge: tag `v2.16.0` and let the release workflow publish image + Helm chart